### PR TITLE
Fix virtual stack operation on retrieving global variable

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -518,6 +518,7 @@ func (p *Parser) parseVariable() ast.Expression {
 			}
 		}
 	}
+	p.pushStack()
 	return ast.Variable{Identifier: p.currentToken}
 }
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -98,12 +98,12 @@ func TestParsePrimary(t *testing.T) {
 }
 
 func TestParseArgumentVariable(t *testing.T) {
-	input := "func f(a, b, c) { 1 + b; }"
+	input := "var a = 0; f(a, 1, 2); func f(a, b, c) { 1 + b; }"
 	lexer := lexer.New("script", input)
 	parser := New(lexer)
 	stmt := parser.ParseProgram()
 
-	f, ok := stmt[0].(ast.Function)
+	f, ok := stmt[2].(ast.Function)
 	if !ok {
 		t.Fatalf("Statement is not function")
 	}


### PR DESCRIPTION
## What

```
var n = 10;
f(n);
func f(n) {
    putn n;
}
```

```
$ make run_test_script
go run cmd/sfflt_lang.go -format pretty test.sflt
fflt_lang test.fflt
Runtime error: copy stack[1] is out of index. stack length: 1 at test.fflt:10:3
```

## Why

Virtual stack was not popped when parsing global variables