### PR TITLE
Fix virtual stack operation on assign

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -331,6 +331,7 @@ func (p *Parser) parseAssign() ast.Expression {
 			p.parseError(p.currentToken, "Can not assign to argument variable.")
 			return nil
 		}
+		p.popStack()
 		return ast.Assign{Target: variable.Identifier, Expression: right}
 	}
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -98,12 +98,12 @@ func TestParsePrimary(t *testing.T) {
 }
 
 func TestParseArgumentVariable(t *testing.T) {
-	input := "var a = 0; f(a, 1, 2); func f(a, b, c) { 1 + b; }"
+	input := "var a = 0; a = 0; f(a, 1, 2); func f(a, b, c) { 1 + b; }"
 	lexer := lexer.New("script", input)
 	parser := New(lexer)
 	stmt := parser.ParseProgram()
 
-	f, ok := stmt[2].(ast.Function)
+	f, ok := stmt[3].(ast.Function)
 	if !ok {
 		t.Fatalf("Statement is not function")
 	}


### PR DESCRIPTION
## What

```
var a = 0;
a = 1;
f(a);
func f(n) {
    putn n;
}
```

```
$ make run_test_script
go run cmd/sfflt_lang.go -format pretty test.sflt
fflt_lang test.fflt
Runtime error: copy stack[1] is out of index. stack length: 1 at test.fflt:19:3
```

## Why

Virtual stack was not popped when parsing assign expression's lhs
