### PR TITLE
Fix return statement without expression

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -114,7 +114,12 @@ func (c *Compiler) VisitPut(s ast.PutStatement) {
 }
 
 func (c *Compiler) VisitReturn(s ast.Return) {
-	s.Value.Visit(c)
+	if s.Value == nil {
+		c.addInstructionWithParam(PUSH, ZERO)
+	} else {
+		s.Value.Visit(c)
+	}
+
 	if c.compilingFunction.ParamCount != 0 {
 		slideLength := intToBinary(int64(c.compilingFunction.ParamCount))
 		c.addInstructionWithParam(SLIDE, POSI+slideLength)

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -582,6 +582,28 @@ func TestCompileReturn(t *testing.T) {
 	assertInstructions(instructions, expects, t)
 }
 
+func TestCompileEmptyReturn(t *testing.T) {
+	input := "func a() { return; } a();"
+	lexer := lexer.New("script", input)
+	parser := parser.New(lexer)
+	exprs := parser.ParseProgram()
+	compiler := New(exprs)
+
+	instructions := compiler.Compile()
+	expects := []string{
+		"TFLLFLLLFFLFFFFFFLLFFFFLFLFFLFFLFLLFFT",
+		"FTT",
+		"TTT",
+		"TFFLFLLLFFLFFFFFFLLFFFFLFLFFLFFLFLLFFT",
+		"FFFFT",
+		"TLT",
+		"FFFFT",
+		"TLT",
+	}
+
+	assertInstructions(instructions, expects, t)
+}
+
 func TestCompileBreak(t *testing.T) {
 	input := "while(true) { while(true) { break; } break; }"
 	instructions := compile(input, t)

--- a/compiler/resolver.go
+++ b/compiler/resolver.go
@@ -85,8 +85,12 @@ func (r *Resolver) VisitFunction(s ast.Function) {
 	}
 }
 func (r *Resolver) VisitPut(s ast.PutStatement) { s.Expression.Visit(r) }
-func (r *Resolver) VisitReturn(s ast.Return)    { s.Value.Visit(r) }
-func (r *Resolver) VisitBreak(s ast.Break)      {}
+func (r *Resolver) VisitReturn(s ast.Return) {
+	if s.Value != nil {
+		s.Value.Visit(r)
+	}
+}
+func (r *Resolver) VisitBreak(s ast.Break) {}
 func (r *Resolver) VisitIf(s ast.If) {
 	s.Condition.Visit(r)
 	s.Then.Visit(r)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -245,6 +245,11 @@ func (p *Parser) parseReturn() ast.Statement {
 		return nil
 	}
 
+	if p.peekToken.Type == token.SEMICOLON {
+		p.nextToken()
+		return ast.Return{Value: nil}
+	}
+
 	p.nextToken()
 	expr := p.parseExpression()
 	if p.peekToken.Type != token.SEMICOLON {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -722,6 +722,28 @@ func TestParseReturn(t *testing.T) {
 	}
 }
 
+func TestParseEmptyReturn(t *testing.T) {
+	input := "func test() { return; }"
+	lexer := lexer.New("script", input)
+	parser := New(lexer)
+	stmt := parser.ParseProgram()
+
+	funcStmt, ok := stmt[0].(ast.Function)
+	if !ok {
+		t.Fatalf("Statement is not function")
+	}
+
+	r, ok := funcStmt.Body[0].(ast.Return)
+
+	if !ok {
+		t.Fatalf("Body is not Return")
+	}
+
+	if r.Value != nil {
+		t.Fatalf("Expression is not empty")
+	}
+}
+
 func TestParseBreak(t *testing.T) {
 	input := "while(true) break;"
 	lexer := lexer.New("script", input)


### PR DESCRIPTION
## What

Fix compile return statement without expression

```sh
$ cat test.sflt
func test() { return; }

$ make run_test_script
go run cmd/sfflt_lang.go -format pretty test.sflt
test.sflt:1 Error at ';': Unexpect token
test.sflt:1 Error at ';': Expect ';' after statement.
exit status 1
make: *** [Makefile:82: run_test_script] Error 1
```