### PR TITLE
Fix syntax error message

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -190,7 +190,10 @@ func (p *Parser) parseFunctionDeclaration() ast.Statement {
 		return nil
 	}
 
-	body := p.parseBlock().(ast.Block)
+	body, ok := p.parseBlock().(ast.Block)
+	if !ok {
+		return nil
+	}
 
 	p.isFunction = false
 	p.endScope()

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -479,6 +479,8 @@ func (p *Parser) parseAssign() ast.Expression {
 
 	switch p.peekToken.Type {
 	case token.ASSIGN:
+		targetToken := p.currentToken
+
 		p.nextToken()
 		p.nextToken()
 
@@ -486,11 +488,11 @@ func (p *Parser) parseAssign() ast.Expression {
 		right := p.parseAssign()
 		target, ok := expr.(ast.Assignable)
 		if !ok {
-			p.parseError(p.currentToken, "Invalid assignment target.")
+			p.parseError(targetToken, "Invalid assignment target.")
 			return nil
 		}
 		if !target.CanAssign() {
-			p.parseError(p.currentToken, "Invalid assignment target.")
+			p.parseError(targetToken, "Invalid assignment target.")
 			return nil
 		}
 		p.popStack()


### PR DESCRIPTION
## What

1. Fix syntax error message for assign

before
```sh
$ cat test.sflt
func test(a) {
    a = a + 1;
}
$ make run_test_script
test.sflt:2 Error at '1': Invalid assignment target.
```

after
```
$ cat test.sflt
func test(a) {
    a = a + 1;
}
$ make run_test_script
test.sflt:2 Error at 'a': Invalid assignment target.
```

2. Fix syntax error on pasing function body

before
```sh
$ cat test.sflt
func test(a) {
    a
}
$ make run_test_script
panic: interface conversion: ast.Statement is nil, not ast.Block
```

after
```
$ cat test.sflt
func test(a) {
    a
}
$ make run_test_script
test.sflt:3 Error at '}': Expect ';' after statement.
test.sflt:4 Error at end: Expect '}' after statements.
```