### PR TITLE
Fix calculating stack top on parsing call function

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -643,6 +643,7 @@ func (p *Parser) parseCall() ast.Expression {
 			p.parseError(p.currentToken, "Expect ')' after arguments.")
 			return nil
 		}
+		p.discardStack(len(arguments))
 		p.pushStack()
 		return ast.Call{Callee: callee, Arguments: arguments}
 	}
@@ -785,6 +786,10 @@ func (p *Parser) pushStack() {
 
 func (p *Parser) popStack() {
 	p.stackTop--
+}
+
+func (p *Parser) discardStack(n int) {
+	p.stackTop -= n
 }
 
 func (p *Parser) beginScope() {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -631,6 +631,7 @@ func (p *Parser) parseCall() ast.Expression {
 		if p.currentToken.Type != token.RPAREN {
 			for {
 				arguments = append(arguments, p.parseExpression())
+				p.pushStack()
 
 				if !p.matchToken(token.COMMA) {
 					break

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -959,6 +959,48 @@ func TestParseFunction(t *testing.T) {
 	}
 }
 
+func TestParseFunctionWithCall(t *testing.T) {
+	input := "func test1(a, b) { test2(a, b); }"
+	lexer := lexer.New("script", input)
+	parser := New(lexer)
+	stmt := parser.ParseProgram()
+
+	funcStmt, ok := stmt[0].(ast.Function)
+	expStmt, ok := funcStmt.Body[0].(ast.ExpressionStatement)
+
+	if !ok {
+		t.Fatalf("Body is not ExpressionStatement")
+	}
+
+	exp := expStmt.Expression
+	call, ok := exp.(ast.Call)
+	if !ok {
+		t.Fatalf("Not Call")
+	}
+
+	first, ok := call.Arguments[0].(ast.Variable)
+	if !ok {
+		t.Fatalf("First arguments is not variable")
+	}
+
+	if first.RelativeIndex != 0 {
+		t.Fatalf("First argument's relative index is not match")
+	}
+
+	second, ok := call.Arguments[1].(ast.Variable)
+	if !ok {
+		t.Fatalf("Second arguments is not variable")
+	}
+
+	if second.RelativeIndex != 1 {
+		t.Fatalf("Second argument's relative index is not match")
+	}
+
+	if parser.stackTop != 0 {
+		t.Fatalf("Parser's stack top does not match")
+	}
+}
+
 func TestParseBlock(t *testing.T) {
 	input := "{ a; b; }"
 	lexer := lexer.New("script", input)


### PR DESCRIPTION
## What

Fix that bug↓

```
func test1(a, b) {
    test2(a, b);
}

func test2(a, b) {
    putn a;
    putn b;
}

test1(1, 2);
```

```sh
make run_test_script
11 # expect 12
```

